### PR TITLE
fix the variable naming for AD9833 object

### DIFF
--- a/jammer_hardware_source/arduino_code/wearable_microphone_jammer/wearable_microphone_jammer.ino
+++ b/jammer_hardware_source/arduino_code/wearable_microphone_jammer/wearable_microphone_jammer.ino
@@ -75,7 +75,7 @@ int RXLED = 17;  // The RX LED has a defined Arduino pin
 
 //--------------- Create an AD9833 object ----------------
 // Note, SCK and MOSI must be connected to CLK and DAT pins on the AD9833 for SPI
-AD9833 gen_1(FNC_PIN_1);       // Defaults to 25MHz internal reference frequency
+AD9833 gen(FNC_PIN_1);       // Defaults to 25MHz internal reference frequency
 
 void setup() {
   //start gen


### PR DESCRIPTION
HI, 
this is really interesting work
fixing the variable name, 

is there a another multiple wave generator version ?
or just a missing spot when you clean up the code.